### PR TITLE
fix: agent message flickering

### DIFF
--- a/lib/util/unsafe.go
+++ b/lib/util/unsafe.go
@@ -1,0 +1,12 @@
+package util
+
+import (
+	"reflect"
+	"unsafe"
+)
+
+// Based on https://stackoverflow.com/a/60598827
+func GetUnexportedField[T any](obj *T, fieldName string) any {
+	field := reflect.ValueOf(obj).Elem().FieldByName(fieldName)
+	return reflect.NewAt(field.Type(), unsafe.Pointer(field.UnsafeAddr())).Elem().Interface()
+}


### PR DESCRIPTION
Problem: agent messages often flicker when updated. Notice the extra lines that appear for a fraction of a second in the recording below.

https://github.com/user-attachments/assets/63590135-c612-42e1-9b70-3423946fdb80

It's because we sometimes capture the terminal screen while it's being redrawn and render an incomplete agent message, which appears to flicker.

This PR:
1. adds a kind of "vsync" that ensures the screen is stable before we capture it
2. fixes a race condition that sometimes causes an initial flicker right after a user message is posted
3. removes a hack to work around a bug in claude 0.2.70.

Points 1. and 2. should address the flickering, and 3. is maintenance work.