### PR TITLE
fix: refactor agent type parsing and run lint in CI

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -2,20 +2,34 @@ name: Go Tests
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
 
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Set up Go
-      uses: actions/setup-go@v5
-      with:
-        go-version: 'stable'
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "stable"
 
-    - name: Test
-      run: go test -count=1 -v ./...
+      - name: Test
+        run: go test -count=1 -v ./...
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "stable"
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
+        with:
+          version: v2.1

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,12 @@
+version: "2"
+linters:
+  enable:
+    - exhaustive
+  settings:
+    exhaustive:
+      check:
+        - "switch"
+        - "map"
+    staticcheck:
+      checks:
+        - "-QF1001" # disable "could apply De Morgan's law"

--- a/cmd/attach/attach.go
+++ b/cmd/attach/attach.go
@@ -80,7 +80,9 @@ func ReadScreenOverHTTP(ctx context.Context, url string, ch chan<- httpapi.Scree
 	if err != nil {
 		return xerrors.Errorf("failed to do request: %w", err)
 	}
-	defer res.Body.Close()
+	defer func() {
+		_ = res.Body.Close()
+	}()
 
 	for ev, err := range sse.Read(res.Body, &sse.ReadConfig{
 		// 256KB: screen can be big. The default terminal size is 80x1000,
@@ -115,7 +117,9 @@ func WriteRawInputOverHTTP(ctx context.Context, url string, msg string) error {
 	if err != nil {
 		return xerrors.Errorf("failed to do request: %w", err)
 	}
-	defer res.Body.Close()
+	defer func() {
+		_ = res.Body.Close()
+	}()
 	if res.StatusCode != http.StatusOK {
 		return xerrors.Errorf("failed to write raw input: %w", errors.New(res.Status))
 	}
@@ -132,7 +136,9 @@ func runAttach(remoteUrl string) error {
 	if err != nil {
 		return xerrors.Errorf("failed to make raw: %w", err)
 	}
-	defer term.Restore(stdin, oldState)
+	defer func() {
+		_ = term.Restore(stdin, oldState)
+	}()
 
 	stdinWriter := &ChannelWriter{
 		ch: make(chan []byte, 4096),

--- a/lib/httpapi/embed.go
+++ b/lib/httpapi/embed.go
@@ -87,7 +87,9 @@ func FileServerWithIndexFallback(chatBasePath string) http.Handler {
 		// Try to serve the file directly
 		f, err := chatFS.Open(trimmedPath)
 		if err == nil {
-			defer f.Close()
+			defer func() {
+				_ = f.Close()
+			}()
 			fileServer.ServeHTTP(w, r)
 			return
 		}

--- a/lib/httpapi/server_test.go
+++ b/lib/httpapi/server_test.go
@@ -55,7 +55,9 @@ func TestOpenAPISchema(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to open disk schema: %s", err)
 	}
-	defer diskSchemaFile.Close()
+	defer func() {
+		_ = diskSchemaFile.Close()
+	}()
 
 	diskSchemaBytes, err := io.ReadAll(diskSchemaFile)
 	if err != nil {

--- a/lib/screentracker/conversation_test.go
+++ b/lib/screentracker/conversation_test.go
@@ -186,7 +186,7 @@ func TestMessages(t *testing.T) {
 		assert.Equal(t, []st.ConversationMessage{
 			agentMsg(0, "1"),
 		}, msgs)
-		nowWrapper.Time = nowWrapper.Time.Add(1 * time.Second)
+		nowWrapper.Time = nowWrapper.Add(1 * time.Second)
 		c.AddSnapshot("1")
 		assert.Equal(t, msgs, c.Messages())
 	})


### PR DESCRIPTION
It was easy to forget to add new agent types with the previous method.