### PR TITLE
fix: improve support for running agentapi under a subpath

### DIFF
--- a/chat/src/components/chat-provider.tsx
+++ b/chat/src/components/chat-provider.tsx
@@ -57,7 +57,8 @@ export function ChatProvider({ children }: PropsWithChildren) {
   const [serverStatus, setServerStatus] = useState<ServerStatus>("unknown");
   const eventSourceRef = useRef<EventSource | null>(null);
   const searchParams = useSearchParams();
-  const agentAPIUrl = searchParams.get("url") || window.location.origin;
+  const defaultAgentAPIURL = new URL("../../", window.location.href).toString();
+  const agentAPIUrl = searchParams.get("url") || defaultAgentAPIURL;
 
   // Set up SSE connection to the events endpoint
   useEffect(() => {

--- a/lib/httpapi/server.go
+++ b/lib/httpapi/server.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"path/filepath"
 	"sync"
 	"time"
 
@@ -33,6 +34,7 @@ type Server struct {
 	agentio      *termexec.Process
 	agentType    mf.AgentType
 	emitter      *EventEmitter
+	chatBasePath string
 }
 
 func (s *Server) GetOpenAPI() string {
@@ -95,10 +97,11 @@ func NewServer(ctx context.Context, agentType mf.AgentType, process *termexec.Pr
 		agentio:      process,
 		agentType:    agentType,
 		emitter:      emitter,
+		chatBasePath: chatBasePath,
 	}
 
 	// Register API routes
-	s.registerRoutes(chatBasePath)
+	s.registerRoutes()
 
 	return s
 }
@@ -116,7 +119,7 @@ func (s *Server) StartSnapshotLoop(ctx context.Context) {
 }
 
 // registerRoutes sets up all API endpoints
-func (s *Server) registerRoutes(chatBasePath string) {
+func (s *Server) registerRoutes() {
 	// GET /status endpoint
 	huma.Get(s.api, "/status", s.getStatus, func(o *huma.Operation) {
 		o.Description = "Returns the current status of the agent."
@@ -158,7 +161,7 @@ func (s *Server) registerRoutes(chatBasePath string) {
 	s.router.Handle("/", http.HandlerFunc(s.redirectToChat))
 
 	// Serve static files for the chat interface under /chat
-	s.registerStaticFileRoutes(chatBasePath)
+	s.registerStaticFileRoutes()
 }
 
 // getStatus handles GET /status
@@ -305,8 +308,8 @@ func (s *Server) Stop(ctx context.Context) error {
 }
 
 // registerStaticFileRoutes sets up routes for serving static files
-func (s *Server) registerStaticFileRoutes(chatBasePath string) {
-	chatHandler := FileServerWithIndexFallback(chatBasePath)
+func (s *Server) registerStaticFileRoutes() {
+	chatHandler := FileServerWithIndexFallback(s.chatBasePath)
 
 	// Mount the file server at /chat
 	s.router.Handle("/chat", http.StripPrefix("/chat", chatHandler))
@@ -314,5 +317,5 @@ func (s *Server) registerStaticFileRoutes(chatBasePath string) {
 }
 
 func (s *Server) redirectToChat(w http.ResponseWriter, r *http.Request) {
-	http.Redirect(w, r, "/chat/embed", http.StatusTemporaryRedirect)
+	http.Redirect(w, r, filepath.Join(s.chatBasePath, "embed"), http.StatusTemporaryRedirect)
 }


### PR DESCRIPTION
Relates to https://github.com/coder/coder/issues/18779

Previously, we had been defaulting `agentAPIURL` to `window.location.origin` which assumes the application owns its subdomain. This is not necessarily the case  if `agentapi` is running under a subpath.

A 'good enough' fix seems to be defaulting to "two levels up" from `/chat/embed`.
Additionally, when redirecting to `/chat/embed` from `/`, we also need to take `chatBasePath` into account.

