### PR TITLE
fix: build release binaries only when a release gets published

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Build Release Binaries
 
 on:
   release:
-    types: [created, published, edited]
+    types: [published]
   push:
     branches: [ main ]
   workflow_dispatch:


### PR DESCRIPTION
Previously, when a new release was published, the workflow to build release binaries would run twice simultaneously: once for the "published" tag and once for the "edited" tag. This caused a race condition where binaries would sometimes fail to upload because two workflows were trying to upload items under the same names.
