### PR TITLE
ci: set CGO_ENABLED=0 for legacy glibc compat

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -17,7 +17,7 @@ jobs:
           go-version: "stable"
 
       - name: Test
-        run: go test -count=1 -v ./...
+        run: CGO_ENABLED=0 go test -count=1 -v ./...
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
           read -r goos goarch artifact_name <<< "$variant"
 
           echo "Building for GOOS=$goos GOARCH=$goarch..."
-          GOOS=$goos GOARCH=$goarch BINPATH="out/$artifact_name" make build
+          CGO_ENABLED=0 GOOS=$goos GOARCH=$goarch BINPATH="out/$artifact_name" make build
         done
 
     - name: Upload Build Artifact

--- a/Makefile
+++ b/Makefile
@@ -17,4 +17,4 @@ embed: $(CHAT_SOURCES_STAMP)
 
 .PHONY: build
 build: embed
-	go build -o ${BINPATH} main.go
+	CGO_ENABLED=0 go build -o ${BINPATH} main.go


### PR DESCRIPTION
Should help agentapi work on older distros like Ubuntu Focal

```
agentapi: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by agentapi)
```