### PR TITLE
ci: fix release build step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.6.3
+
+- CI fixes.
+
 ## v0.6.2
 
 - Fix incorrect version string.

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ embed: $(CHAT_SOURCES_STAMP)
 	@echo "Chat build is up to date."
 
 .PHONY: build
-build: gen embed
+build: embed
 	CGO_ENABLED=0 go build -o ${BINPATH} main.go
 
 .PHONY: gen

--- a/chat/package.json
+++ b/chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chat",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -2,4 +2,4 @@
 
 package version
 
-var Version = "0.6.2"
+var Version = "0.6.3"

--- a/openapi.json
+++ b/openapi.json
@@ -307,7 +307,7 @@
   "info": {
     "description": "HTTP API for Claude Code, Goose, and Aider.\n\nhttps://github.com/coder/agentapi",
     "title": "AgentAPI",
-    "version": "0.6.2"
+    "version": "0.6.3"
   },
   "openapi": "3.1.0",
   "paths": {


### PR DESCRIPTION
Our CI job was running `GOOS=xxx GOARCH=yyy make build`. Recent changes made this call `go run` which would end up causing an exec format error.
Since this step is now run in CI pipelines, removing the `gen` target as a dependency of the `build target`.