### PR TITLE
fix: improve autoscroll behaviour

### DIFF
--- a/chat/src/components/message-list.tsx
+++ b/chat/src/components/message-list.tsx
@@ -74,7 +74,11 @@ export default function MessageList({messages}: MessageListProps) {
 
     scrollAreaRef.addEventListener("scroll", handleScroll);
     scrollAreaRef.addEventListener("scrollend", () => isProgrammaticScrollRef.current = false);
-    return () => scrollAreaRef.removeEventListener("scroll", handleScroll);
+    return () => {
+      scrollAreaRef.removeEventListener("scroll", handleScroll)
+      scrollAreaRef.removeEventListener("scrollend", () => isProgrammaticScrollRef.current = false);
+
+    };
   }, [checkIfAtBottom, scrollAreaRef]);
 
   // Handle auto-scrolling when messages change


### PR DESCRIPTION
## Description

Autoscroll/follow only kicks in if:
- User is already at the bottom of the screen, we follow the new content
- User sends a new message, we start following the new content.

In case when user manually scrolls up, follow is disabled.
