### PR TITLE
feat: temporarily remove report_task tool call logging

### DIFF
--- a/lib/httpapi/server.go
+++ b/lib/httpapi/server.go
@@ -226,7 +226,7 @@ func NewServer(ctx context.Context, config ServerConfig) (*Server, error) {
 	humaConfig.Info.Description = "HTTP API for Claude Code, Goose, and Aider.\n\nhttps://github.com/coder/agentapi"
 	api := humachi.New(router, humaConfig)
 	formatMessage := func(message string, userInput string) string {
-		return mf.FormatAgentMessage(config.AgentType, message, userInput, logger)
+		return mf.FormatAgentMessage(config.AgentType, message, userInput)
 	}
 
 	isAgentReadyForInitialPrompt := func(message string) bool {

--- a/lib/msgfmt/message_box.go
+++ b/lib/msgfmt/message_box.go
@@ -1,7 +1,6 @@
 package msgfmt
 
 import (
-	"log/slog"
 	"strings"
 )
 
@@ -102,7 +101,7 @@ func removeAmpMessageBox(msg string) string {
 	return formattedMsg
 }
 
-func removeClaudeReportTaskToolCall(msg string, logger *slog.Logger) string {
+func removeClaudeReportTaskToolCall(msg string) string {
 	// Remove all tool calls that start with `● coder - coder_report_task (MCP)` till we encounter the next line starting with ●
 	lines := strings.Split(msg, "\n")
 
@@ -145,10 +144,6 @@ func removeClaudeReportTaskToolCall(msg string, logger *slog.Logger) string {
 	for i := len(toolCallIdxs) - 1; i >= 0; i-- {
 		idxPair := toolCallIdxs[i]
 		start, end := idxPair[0], idxPair[1]
-
-		// Capture the tool call content before removing it
-		toolCallContent := strings.Join(lines[start:end], "\n")
-		logger.Info("Removing tool call", "content", toolCallContent)
 
 		lines = append(lines[:start], lines[end:]...)
 	}

--- a/lib/msgfmt/msgfmt.go
+++ b/lib/msgfmt/msgfmt.go
@@ -1,7 +1,6 @@
 package msgfmt
 
 import (
-	"log/slog"
 	"strings"
 )
 
@@ -255,10 +254,10 @@ func formatGenericMessage(message string, userInput string, agentType AgentType)
 	return message
 }
 
-func formatClaudeMessage(message string, userInput string, logger *slog.Logger) string {
+func formatClaudeMessage(message string, userInput string) string {
 	message = RemoveUserInput(message, userInput, AgentTypeClaude)
 	message = removeMessageBox(message)
-	message = removeClaudeReportTaskToolCall(message, logger)
+	message = removeClaudeReportTaskToolCall(message)
 	message = trimEmptyLines(message)
 	return message
 }
@@ -284,10 +283,10 @@ func formatAmpMessage(message string, userInput string) string {
 	return message
 }
 
-func FormatAgentMessage(agentType AgentType, message string, userInput string, logger *slog.Logger) string {
+func FormatAgentMessage(agentType AgentType, message string, userInput string) string {
 	switch agentType {
 	case AgentTypeClaude:
-		return formatClaudeMessage(message, userInput, logger)
+		return formatClaudeMessage(message, userInput)
 	case AgentTypeGoose:
 		return formatGenericMessage(message, userInput, agentType)
 	case AgentTypeAider:

--- a/lib/msgfmt/msgfmt_test.go
+++ b/lib/msgfmt/msgfmt_test.go
@@ -2,7 +2,6 @@ package msgfmt
 
 import (
 	"embed"
-	"log/slog"
 	"path"
 	"strings"
 	"testing"
@@ -234,7 +233,7 @@ func TestFormatAgentMessage(t *testing.T) {
 					assert.NoError(t, err)
 					expected, err := testdataDir.ReadFile(path.Join(dir, string(agentType), c.Name(), "expected.txt"))
 					assert.NoError(t, err)
-					assert.Equal(t, string(expected), FormatAgentMessage(agentType, string(msg), string(userInput), slog.Default()))
+					assert.Equal(t, string(expected), FormatAgentMessage(agentType, string(msg), string(userInput)))
 				})
 			}
 		})


### PR DESCRIPTION
This is getting very noisy, and the log files will get very big really fast. Temporarily removing it till we figure out a better solution.