### PR TITLE
fix(httpapi): drop x\b workaround for fixed Claude Code 0.2.70 paste-echo bug

### DIFF
--- a/lib/httpapi/claude.go
+++ b/lib/httpapi/claude.go
@@ -22,10 +22,6 @@ func formatPaste(message string) []st.MessagePart {
 
 func formatClaudeCodeMessage(message string) []st.MessagePart {
 	parts := make([]st.MessagePart, 0)
-	// janky hack: send a random character and then a backspace because otherwise
-	// Claude Code echoes the startSeq back to the terminal.
-	// This basically simulates a user typing and then removing the character.
-	parts = append(parts, st.MessagePartText{Content: "x\b", Hidden: true})
 	parts = append(parts, formatPaste(message)...)
 
 	return parts


### PR DESCRIPTION
Fixes #223.

The `x\b` workaround added in b732081 to mask Claude Code 0.2.70's bracketed-paste echo bug now produces a visible stray `x` at the end of every prompt with current Claude Code (2.1.x). The original commit message promised removal "a couple of days after the new version is released" — almost a year on, the hack is still here and is now actively breaking input (e.g. slash-command argument parsing receives `/cmd argx` instead of `/cmd arg`).

The companion `removeDuplicateClaude_0_2_70_Output` function from the original commit is already gone from the codebase, so this reverts only the `lib/httpapi/claude.go` portion.

Verified locally against Claude Code 2.1.143: prompts render cleanly without the trailing `x`, and slash-command arguments parse correctly.